### PR TITLE
context._shadow is null when using L.divIcon and causes an error

### DIFF
--- a/src/leaflet-layervisibility.js
+++ b/src/leaflet-layervisibility.js
@@ -48,7 +48,9 @@ L.LayerGroup.include({
 
 function setMarkerShadowDisplayStyle(value, context) {
     // eslint-disable-next-line no-underscore-dangle
-    context._shadow.style.display = value;
+    if(context._shadow){
+        context._shadow.style.display = value;
+    }
     return context;
 }
 


### PR DESCRIPTION
(Uncaught TypeError: context._shadow is null)